### PR TITLE
Use latest version of facebook api

### DIFF
--- a/public/scripts/sharing.js
+++ b/public/scripts/sharing.js
@@ -18,7 +18,7 @@
     FB.init({
       appId: '144441392317207'
     , xfbml: true
-    , version: 'v2.0'
+    , version: 'v2.6'
     });
   };
 


### PR DESCRIPTION
Buenas estimados de Data,
Hace unos días me llego el siguiente mail de Facebook:

> Hi Agustin,
> Legado Bicentenario has been making recent API calls to Graph API v2.0, which will reach the end of the 2-year deprecation window on Monday, August 8, 2016. Please migrate all calls to v2.1 or higher in order to avoid potential broken experiences.

> We recommend using our new Graph API Upgrade Tool to see which of your calls are affected by this change as well as any replacement calls in newer versions. You can also use our changelog to see the full list of changes.

> You can view this and other Developer Notifications related to your app, Legado Bicentenario, in the App Dashboard.
> Thanks,
> The Facebook Team

Intenté usar la API Upgrade Tool pero me muestra el siguiente mensaje:

> Your app hasn't made enough calls to the Graph API to show any info, or there are no changes for the methods you selected between v2.0 and v2.6

Estuve viendo el changelog y el salto de version no nos afecta en nada dado los datos que estamos pidiendo de los usuarios (información básica personal). No se si el sitio se sigue usando o no pero el cambió de version de la API debería de tirar hasta Abril de 2018 según Facebook.

No me acuerdo exactamente como subirlo a producción pero si aprueban el cambio lo mergeo y tanteo como hacerlo. Cruzo los dedos para no romper nada 😨 